### PR TITLE
Add contract aliases

### DIFF
--- a/src/actions/sendFlowTransaction.ts
+++ b/src/actions/sendFlowTransaction.ts
@@ -10,7 +10,7 @@ import {
   parseFlowArgs,
 } from '../helpers';
 import { AuthorizationFunction, FlowType } from '../interfaces';
-import { XOR } from '../types';
+import { XOR } from '../types/internal';
 
 export type SendFlowTransactionProps = XOR<
   SendFlowTransactionAuthorizationsProps,

--- a/src/constants/coreContractAliases.constant.ts
+++ b/src/constants/coreContractAliases.constant.ts
@@ -1,0 +1,33 @@
+import { ContractAlias } from '../interfaces';
+import { FlowNetwork } from '../types';
+import { MakeRequired, Subset } from '../types/internal';
+
+type CoreContractNetwork = Subset<FlowNetwork, 'testnet' | 'mainnet'>;
+
+interface CoreContractAlias extends Omit<ContractAlias, 'addresses'> {
+  addresses: MakeRequired<ContractAlias['addresses'], CoreContractNetwork>;
+}
+
+export const coreContractAliases: CoreContractAlias[] = [
+  {
+    alias: '0xFlowToken',
+    addresses: {
+      testnet: '0x7e60df042a9c0868',
+      mainnet: '0x1654653399040a61',
+    },
+  },
+  {
+    alias: '0xNonFungibleToken',
+    addresses: {
+      testnet: '0x631e88ae7f1d7c20',
+      mainnet: '0x1d7e57aa55817448',
+    },
+  },
+  {
+    alias: '0xFungibleToken',
+    addresses: {
+      testnet: '0x9a0766d93b6608b7',
+      mainnet: '0xf233dcee88fe0abe',
+    },
+  },
+] as const;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './coreContractAliases.constant';

--- a/src/helpers/configureChains.ts
+++ b/src/helpers/configureChains.ts
@@ -1,13 +1,15 @@
 import * as fcl from '@onflow/fcl';
 
+import { coreContractAliases } from '../constants';
+import { ContractAlias } from '../interfaces';
+import { FlowNetwork } from '../types';
+
 export type FlowDiscoveryWalletMethod =
   | 'IFRAME/RPC'
   | 'POP/RPC'
   | 'TAB/RPC'
   | 'HTTP/POST'
   | 'EXT/RPC';
-
-export type FlowNetwork = 'local' | 'canarynet' | 'testnet' | 'mainnet';
 
 export interface ConfigureChainsProps {
   title: string;
@@ -18,6 +20,33 @@ export interface ConfigureChainsProps {
   discoveryAuthnEndpoint?: string;
   network: FlowNetwork;
   limit?: number;
+  /**
+   * Add core contracts as imports inside Flow interactions.
+   * Only works for `testnet` and `mainnet`.
+   *
+   * @default true
+   */
+  addCoreContracts?: boolean;
+  /**
+   * Add custom contracts as imports inside Flow interactions. The network will be automatically selected based on the `network` property.
+   *
+   * Contract aliases must start with '0x'.
+   *
+   * Example:
+   *
+   * ```ts
+   * const contractAddresses = {
+   *  '0xDoodles': {
+   *    mainnet: '0xe81193c424cfd3fb',
+   *  }
+   * }
+   * ```
+   * And inside a Flow interaction:
+   * ```cadence
+   * import Doodles from 0xDoodles
+   * ```
+   */
+  contractAddresses?: ContractAlias[];
 }
 
 export const configureChains = (
@@ -30,6 +59,8 @@ export const configureChains = (
     discoveryAuthnEndpoint,
     network,
     limit = 100,
+    contractAddresses,
+    addCoreContracts = true,
   }: ConfigureChainsProps,
   extraConfigs: Record<string, unknown> = {},
 ) => {
@@ -43,6 +74,20 @@ export const configureChains = (
     'flow.network': network,
     'fcl.limit': limit,
   });
+
+  if (addCoreContracts && (network === 'testnet' || network === 'mainnet')) {
+    for (const coreContractAlias of coreContractAliases) {
+      const contractAddress = coreContractAlias.addresses[network];
+      fcl.config.put(coreContractAlias.alias, contractAddress);
+    }
+  }
+
+  if (contractAddresses) {
+    for (const contractAlias of contractAddresses) {
+      const contractAddress = contractAlias.addresses[network];
+      fcl.config.put(contractAlias.alias, contractAddress);
+    }
+  }
 
   for (const [key, value] of Object.entries(extraConfigs)) {
     fcl.config.put(key, value);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 export * from './actions';
+export * from './constants';
 export * from './errors';
 export * from './helpers';
 export * from './interfaces';
+export * from './types';

--- a/src/interfaces/contractAlias.interface.ts
+++ b/src/interfaces/contractAlias.interface.ts
@@ -1,0 +1,8 @@
+import { FlowNetwork, ZeroXString } from '../types';
+
+export type ContractAlias = {
+  alias: ZeroXString;
+  addresses: {
+    [K in FlowNetwork]?: ZeroXString;
+  };
+};

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,4 +1,5 @@
 export * from './authz.interface';
+export * from './contractAlias.interface';
 export * from './flowAccount.interface';
 export * from './flowAuthorizationFunction.interface';
 export * from './flowEvent.interface';

--- a/src/types/flowNetwork.type.ts
+++ b/src/types/flowNetwork.type.ts
@@ -1,0 +1,1 @@
+export type FlowNetwork = 'local' | 'canarynet' | 'testnet' | 'mainnet';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from './flowNetwork.type';
+export * from './zeroXString.type';

--- a/src/types/internal/index.ts
+++ b/src/types/internal/index.ts
@@ -1,0 +1,3 @@
+export * from './makeRequired.type';
+export * from './subset.type';
+export * from './xor.type';

--- a/src/types/internal/makeRequired.type.ts
+++ b/src/types/internal/makeRequired.type.ts
@@ -1,0 +1,3 @@
+// Make specific properties of a type required
+export type MakeRequired<T, K extends keyof T> = Omit<T, K> &
+  Required<Pick<T, K>>;

--- a/src/types/internal/subset.type.ts
+++ b/src/types/internal/subset.type.ts
@@ -1,0 +1,2 @@
+// Enforce that all elements of T are in U
+export type Subset<T, U> = T extends U ? T : never;

--- a/src/types/internal/xor.type.ts
+++ b/src/types/internal/xor.type.ts
@@ -1,4 +1,5 @@
-export type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
+type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
+
 export type XOR<T, U> = T | U extends object
   ? (Without<T, U> & U) | (Without<U, T> & T)
   : T | U;

--- a/src/types/zeroXString.type.ts
+++ b/src/types/zeroXString.type.ts
@@ -1,0 +1,1 @@
+export type ZeroXString = `0x${string}`;


### PR DESCRIPTION
- Add contract aliases (from FCL) for Flow interactions, inside the `configurableChains` function.
    - Configurable contract aliases for custom contracts.
    - Core contracts aliases boolean for core contracts.
 
This allows for easier Flow interactions, and to add all contract addresses in the code, removing the necessity to use env vars for each contract.

Example:

Typescript:
```ts
const contractAddresses = {
    '0xDoodles': {
        mainnet: '0xe81193c424cfd3fb',
    }
}
```

```cdc
import Doodles from 0xDoodles
```